### PR TITLE
Align explorer layout top left

### DIFF
--- a/brainPop/Frontend/src/assets/styles/style_Desktop3.css
+++ b/brainPop/Frontend/src/assets/styles/style_Desktop3.css
@@ -6,6 +6,13 @@
 
 }
 
+/* When the explorer is shown we want the body to align everything to the top
+   left so the content starts directly below the navbar */
+body.left-aligned {
+    align-items: flex-start;
+    justify-content: flex-start;
+}
+
 .breadcrumb-container {
     color: var(--primary-color);
     display: flex;

--- a/brainPop/Frontend/src/components/Explorer/Explorer_main.vue
+++ b/brainPop/Frontend/src/components/Explorer/Explorer_main.vue
@@ -69,7 +69,7 @@
 </template>
 
 <script>
-import { reactive, computed } from "vue";
+import { reactive, computed, onMounted, onUnmounted } from "vue";
 
 export default {
   name: "Desktop",
@@ -87,6 +87,14 @@ export default {
         y: 0,
         targetItem: null
       }
+    });
+
+    onMounted(() => {
+      document.body.classList.add('left-aligned');
+    });
+
+    onUnmounted(() => {
+      document.body.classList.remove('left-aligned');
     });
 
     const openModal = () => {


### PR DESCRIPTION
## Summary
- ensure explorer content starts under navbar
- remove body centering while explorer is open

## Testing
- `npm run build`