### PR TITLE
Fix context menu position in explorer

### DIFF
--- a/brainPop/Frontend/src/assets/styles/style_Desktop3.css
+++ b/brainPop/Frontend/src/assets/styles/style_Desktop3.css
@@ -182,3 +182,14 @@ body.left-aligned {
 
 }
 
+.context-menu {
+    background: var(--grayBackground);
+    backdrop-filter: blur(10px);
+    border-radius: 5px;
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    z-index: 1000;
+}
+

--- a/brainPop/Frontend/src/components/Explorer/Explorer_main.vue
+++ b/brainPop/Frontend/src/components/Explorer/Explorer_main.vue
@@ -89,12 +89,20 @@ export default {
       }
     });
 
+    const handleClickOutside = (event) => {
+      if (!event.target.closest('.context-menu')) {
+        closeContextMenu();
+      }
+    };
+
     onMounted(() => {
       document.body.classList.add('left-aligned');
+      document.addEventListener('click', handleClickOutside);
     });
 
     onUnmounted(() => {
       document.body.classList.remove('left-aligned');
+      document.removeEventListener('click', handleClickOutside);
     });
 
     const openModal = () => {
@@ -150,12 +158,13 @@ export default {
 
     const openContextMenu = (event, item) => {
       state.contextMenu.visible = true;
-      state.contextMenu.x = event.pageX;
-      state.contextMenu.y = event.pageY;
+      state.contextMenu.x = event.clientX;
+      state.contextMenu.y = event.clientY;
       state.contextMenu.targetItem = item;
     };
 
     const contextMenuStyles = computed(() => ({
+      position: 'fixed',
       top: `${state.contextMenu.y}px`,
       left: `${state.contextMenu.x}px`
     }));


### PR DESCRIPTION
## Summary
- keep a handleClickOutside helper to close context menu when clicking elsewhere
- place the context menu at the mouse position using `clientX`/`clientY`
- make context menu fixed and styled

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*