### PR TITLE
Switch to Argon2 for password hashing

### DIFF
--- a/brainPop/Backend/package-lock.json
+++ b/brainPop/Backend/package-lock.json
@@ -8,7 +8,8 @@
       "name": "Template_Bun_Elysia",
       "version": "1.0.50",
       "dependencies": {
-        "bcrypt": "^6.0.0",
+        "argon2": "^0.43.0",
+        "argon2id": "^1.0.1",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "pg-promise": "^11.13.0",
@@ -16,7 +17,7 @@
         "sqlite3": "^5.1.7"
       },
       "devDependencies": {
-        "@types/bcrypt": "^5.0.2",
+        "@types/argon2": "^0.15.4",
         "@types/express": "^5.0.2",
         "@types/node": "^22.15.19",
         "@vitest/ui": "latest",
@@ -774,6 +775,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/@phc/format": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@phc/format/-/format-1.0.0.tgz",
+      "integrity": "sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.29",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
@@ -1099,14 +1109,15 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/bcrypt": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-5.0.2.tgz",
-      "integrity": "sha512-6atioO8Y75fNcbmj0G7UjI9lXN2pQ/IGJ2FWT4a/btd0Lk9lQalHLKhkgKVZ3r+spnmWUKfbMi1GEe9wyHQfNQ==",
+    "node_modules/@types/argon2": {
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/@types/argon2/-/argon2-0.15.4.tgz",
+      "integrity": "sha512-fZPJNvZTvoyt/okKhbyj99UsDOwqzEXYPvKqfK26mViH9JB/hOwzUwDUn5qbwq9XJkLw0kDcFNu6+bnb3u5a0A==",
+      "deprecated": "This is a stub types definition. argon2 provides its own type definitions, so you do not need this installed.",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/node": "*"
+        "argon2": "*"
       }
     },
     "node_modules/@types/body-parser": {
@@ -1836,6 +1847,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/argon2": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.43.0.tgz",
+      "integrity": "sha512-u/HKLcbWShVDhkfwI4hWyiUf3qyX8QhTfaIv2cWE18uqhXCmR5hb6Ed7oqYi2KCQegeAnRhiFzbjzm7i5yl1GA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@phc/format": "^1.0.0",
+        "node-addon-api": "^8.3.1",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/argon2id": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/argon2id/-/argon2id-1.0.1.tgz",
+      "integrity": "sha512-rsiD3lX+0L0CsiZARp3bf9EGxprtuWAT7PpiJd+Fk53URV0/USOQkBIP1dLTV8t6aui0ECbymQ9W9YCcTd6XgA==",
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1888,20 +1920,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/bcrypt": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
-      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-addon-api": "^8.3.0",
-        "node-gyp-build": "^4.8.4"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",

--- a/brainPop/Backend/package.json
+++ b/brainPop/Backend/package.json
@@ -12,7 +12,8 @@
     "format": "prettier --write src/**/*.ts"
   },
   "dependencies": {
-    "bcrypt": "^6.0.0",
+    "argon2": "^0.43.0",
+    "argon2id": "^1.0.1",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "pg-promise": "^11.13.0",
@@ -20,7 +21,7 @@
     "sqlite3": "^5.1.7"
   },
   "devDependencies": {
-    "@types/bcrypt": "^5.0.2",
+    "@types/argon2": "^0.15.4",
     "@types/express": "^5.0.2",
     "@types/node": "^22.15.19",
     "@vitest/ui": "latest",

--- a/brainPop/Backend/src/services/registerUser.ts
+++ b/brainPop/Backend/src/services/registerUser.ts
@@ -1,17 +1,11 @@
-import bcrypt from "bcrypt";
+import * as argon2 from "argon2";
+
 import pgPromise from "pg-promise";
 
 const pgp = pgPromise({});
 const db = pgp(process.env.DATABASE_URL as string);
 
-/**
- * Registriert einen neuen Benutzer in der PostgreSQL-Datenbank
- *
- * @param username - Die E-Mail des Benutzers.
- * @param password - Das Passwort des Benutzers.
- * @param repeatPassword - Wiederholung des Passworts.
- * @returns Erfolgs- oder Fehlermeldung.
- */
+
 export async function registerUser(
     username: string,
     password: string,
@@ -44,7 +38,13 @@ export async function registerUser(
         }
 
         // 3. Passwort hashen
-        const hashedPassword = await bcrypt.hash(password, 10);
+        const hashedPassword = await argon2.hash(password, {
+            type: argon2.argon2id,
+            memoryCost: 2 ** 16,
+            timeCost: 3,
+            parallelism: 1
+        });
+
 
         // 4. Benutzer in die Datenbank einfügen
         await db.none(


### PR DESCRIPTION
Replaced bcrypt with Argon2 for improved security and performance in password hashing. Updated dependencies in `package.json` and removed `bcrypt` references. Adjusted hashing parameters to utilize Argon2id with recommended settings.